### PR TITLE
Ensure prediction input matches training feature order

### DIFF
--- a/Backend/app/predict_bp.py
+++ b/Backend/app/predict_bp.py
@@ -2,6 +2,25 @@ from flask import Blueprint, request, jsonify
 import pandas as pd
 import joblib
 
+# 训练模型时使用的特征顺序
+FEATURE_ORDER = [
+    'GENDER',
+    'AGE',
+    'SMOKING',
+    'YELLOW_FINGERS',
+    'ANXIETY',
+    'PEER_PRESSURE',
+    'CHRONIC DISEASE',
+    'FATIGUE',
+    'ALLERGY',
+    'WHEEZING',
+    'ALCOHOL CONSUMING',
+    'COUGHING',
+    'SHORTNESS OF BREATH',
+    'SWALLOWING DIFFICULTY',
+    'CHEST PAIN'
+]
+
 def create_predict_bp(model_path='./models/best_lung_cancer_model.pkl', scaler_path='./models/scaler.pkl'):
     predict_bp = Blueprint('predict_bp', __name__)
 
@@ -43,6 +62,10 @@ def create_predict_bp(model_path='./models/best_lung_cancer_model.pkl', scaler_p
 
         # 年龄标准化
         df_input['AGE'] = scaler.transform(df_input[['AGE']])
+
+        # 按训练时的特征顺序排列
+        df_input = df_input[FEATURE_ORDER]
+
         return df_input
 
     @predict_bp.route('/predict', methods=['POST'])
@@ -55,6 +78,8 @@ def create_predict_bp(model_path='./models/best_lung_cancer_model.pkl', scaler_p
 
             processed = preprocess_input(data)
             print("预处理后数据：\n", processed)
+            print("列顺序检查：", processed.columns.tolist() == FEATURE_ORDER)
+            print("当前列顺序：", processed.columns.tolist())
 
             pred = model.predict(processed)
             print("预测结果：", pred)


### PR DESCRIPTION
## Summary
- define `FEATURE_ORDER` constant for consistent model input
- reorder the DataFrame in `preprocess_input` using `FEATURE_ORDER`
- add logging to confirm column order before predicting

## Testing
- `python -m py_compile Backend/app/predict_bp.py`

------
https://chatgpt.com/codex/tasks/task_e_68556c01f44c832694c5153dea5d2e11